### PR TITLE
Add configurable periodic deduplication task

### DIFF
--- a/src/emailinator/batch.py
+++ b/src/emailinator/batch.py
@@ -1,0 +1,4 @@
+def deduplicate_tasks():
+    """Placeholder for periodic task that deduplicates stored tasks."""
+    # Deduplication logic will be implemented in the future.
+    pass

--- a/src/emailinator/config.json
+++ b/src/emailinator/config.json
@@ -1,0 +1,3 @@
+{
+  "dedupe_interval_seconds": 3600
+}

--- a/src/emailinator/config.py
+++ b/src/emailinator/config.py
@@ -1,0 +1,10 @@
+import json
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).with_name("config.json")
+
+
+def load_config():
+    """Load configuration values from the config file."""
+    with CONFIG_PATH.open() as f:
+        return json.load(f)

--- a/src/emailinator/service.py
+++ b/src/emailinator/service.py
@@ -1,11 +1,39 @@
+import asyncio
+from contextlib import suppress
+
 from fastapi import FastAPI, UploadFile, File, HTTPException
 
+from .batch import deduplicate_tasks
+from .config import load_config
 from .input.email_reader import read_email_bytes
 from .processing.email_parser import extract_text_from_email
-from .processing.task_extractor import extract_tasks_from_text
-from .processing.task_updater import update_tasks_in_db
+from .processing import task_extractor, task_updater
 
 app = FastAPI()
+
+_dedupe_task = None
+
+
+async def _run_periodic_dedupe(interval: float):
+    while True:
+        await asyncio.sleep(interval)
+        deduplicate_tasks()
+
+
+@app.on_event("startup")
+async def _startup_event():
+    config = load_config()
+    interval = config.get("dedupe_interval_seconds", 3600)
+    global _dedupe_task
+    _dedupe_task = asyncio.create_task(_run_periodic_dedupe(interval))
+
+
+@app.on_event("shutdown")
+async def _shutdown_event():
+    if _dedupe_task:
+        _dedupe_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await _dedupe_task
 
 
 @app.post("/emails")
@@ -18,6 +46,6 @@ async def receive_email(file: UploadFile = File(...)):
         raise HTTPException(status_code=400, detail="Invalid email file")
 
     text = extract_text_from_email(msg)
-    tasks = extract_tasks_from_text(text)
-    update_tasks_in_db(tasks)
+    tasks = task_extractor.extract_tasks_from_text(text)
+    task_updater.update_tasks_in_db(tasks)
     return {"task_count": len(tasks)}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test")

--- a/tests/test_batch_task.py
+++ b/tests/test_batch_task.py
@@ -1,0 +1,27 @@
+import sys
+import threading
+
+sys.path.append('src')
+
+import pytest
+
+try:
+    from fastapi.testclient import TestClient
+    import emailinator.service as service
+except ModuleNotFoundError:
+    pytest.skip("fastapi not installed", allow_module_level=True)
+
+app = service.app
+
+
+def test_dedupe_task_runs_periodically(monkeypatch):
+    event = threading.Event()
+
+    def fake_dedupe():
+        event.set()
+
+    monkeypatch.setattr(service, "deduplicate_tasks", fake_dedupe)
+    monkeypatch.setattr(service, "load_config", lambda: {"dedupe_interval_seconds": 0.01})
+
+    with TestClient(app):
+        assert event.wait(0.5)


### PR DESCRIPTION
## Summary
- introduce JSON config and loader for periodic jobs
- run background deduplication placeholder at configurable intervals
- test periodic dedupe runner and provide safe OpenAI defaults for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a261030d888327b3aa4d63d009bf78